### PR TITLE
Cleanup

### DIFF
--- a/shared/rtl/AppDeserGroup.vhd
+++ b/shared/rtl/AppDeserGroup.vhd
@@ -59,9 +59,9 @@ end entity AppDeserGroup;
 
 architecture mapping of AppDeserGroup is
 
-   signal deserData : Slv8Array(23 downto 0);
-   signal dlyLoad   : slv(23 downto 0);
-   signal dlyCfg    : Slv9Array(23 downto 0);
+   signal deserData : Slv8Array(NUM_OF_LANES_G-1 downto 0);
+   signal dlyLoad   : slv(NUM_OF_LANES_G-1 downto 0);
+   signal dlyCfg    : Slv9Array(NUM_OF_LANES_G-1 downto 0);
 
 begin
     
@@ -99,7 +99,7 @@ begin
       generic map (
          TPD_G            => TPD_G,
          SIMULATION_G     => SIMULATION_G,
-         NUM_LANE_G       => 24)
+         NUM_LANE_G       => NUM_OF_LANES_G)
       port map (
          -- Deserialization Interface (deserClk domain)
          deserClk        => sspClk,

--- a/shared/rtl/DigitalAsicStreamAxiV2.vhd
+++ b/shared/rtl/DigitalAsicStreamAxiV2.vhd
@@ -177,6 +177,7 @@ architecture RTL of DigitalAsicStreamAxiV2 is
    signal axilReadMaster   : AxiLiteReadMasterType;
    signal axilReadSlave    : AxiLiteReadSlaveType;
 
+   signal cycleCounter     : slv(15 downto 0);
    
    attribute keep : string;
    attribute keep of r           : signal is "true";
@@ -195,13 +196,15 @@ architecture RTL of DigitalAsicStreamAxiV2 is
    attribute keep of notFull     : signal is "true";
    attribute keep of DeserAxisDualClockFifoFull : signal is "true";
    attribute keep of DeserAxisDualClockFifoWrCnt : signal is "true";
+   attribute keep of cycleCounter : signal is "true";
 
 begin
    
    ----------------------------------------------------------------------------
    -- Cross clocking synchronizers
    ----------------------------------------------------------------------------
-   
+   cycleCounter <= r.stCnt(15 downto 0);
+
    AcqNoSync_U : entity surf.SynchronizerVector
    generic map (
       WIDTH_G => 32)

--- a/shared/rtl/DigitalAsicStreamAxiV2.vhd
+++ b/shared/rtl/DigitalAsicStreamAxiV2.vhd
@@ -364,6 +364,7 @@ begin
          v.txMaster.tUser  := (others => '0');
          v.txMaster.tKeep  := (others => '1');
          v.txMaster.tStrb  := (others => '1');
+         v.txMaster.tData  := (others => '0');
       end if;
       
       case r.state is


### PR DESCRIPTION
AXI stream was keeping garbage from last cycle, and was sent to the PC. Cleaned it up.  Also used generic in some places instead of magic numbers.