### PR TITLE
ID reading based on generic parameters

### DIFF
--- a/python/epix_hr_leap_common/_RegisterControlDualClock.py
+++ b/python/epix_hr_leap_common/_RegisterControlDualClock.py
@@ -33,12 +33,12 @@ class RegisterControlDualClock(pr.Device):
       #Setup registers & variables
       
       self.add(pr.RemoteVariable(name='Version',         description='Version',           offset=0x00000000, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{:#x}',  verify = False, mode='RO'))
-      self.add(pr.RemoteVariable(name=snEnum[0],         description=snEnum[0],           offset=0x00000004, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{:#x}', mode='RO'))
-      self.add(pr.RemoteVariable(name=snEnum[1],         description=snEnum[1],           offset=0x00000008, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{:#x}', mode='RO'))
-      self.add(pr.RemoteVariable(name=snEnum[2],         description=snEnum[2],           offset=0x0000000C, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{:#x}', mode='RO'))
-      self.add(pr.RemoteVariable(name=snEnum[3],         description=snEnum[3],           offset=0x00000010, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{:#x}', mode='RO'))
-      self.add(pr.RemoteVariable(name=snEnum[4],         description=snEnum[4],           offset=0x00000014, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{:#x}', mode='RO'))
-      self.add(pr.RemoteVariable(name=snEnum[5],         description=snEnum[5],           offset=0x00000018, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{:#x}', mode='RO'))
+      
+      for snId in snEnum.keys():
+        self.add(pr.RemoteVariable(name=snEnum[snId],         description=snEnum[snId],           offset=((snId*4)+4), bitSize=32, bitOffset=0, base=pr.UInt, disp = '{:#x}', mode='RO'))
+        
+      self.add(pr.RemoteVariable(name='IDreset',         description='Reset DS2411Core module',         offset=0x000000FC, bitOffset=0, base=pr.UInt, mode='RW'))
+      
       self.add(pr.RemoteVariable(name='GlblRstPolarityN',description='GlblRstPolarityN (active low)',   offset=0x00000100, bitSize=1,  bitOffset=0, base=pr.Bool, mode='RW'))
       self.add(pr.RemoteVariable(name='ClkSyncEn',       description='Enables clock to be available inside ASIC.',   offset=0x00000100, bitSize=1,  bitOffset=1, base=pr.Bool, mode='RW'))
       self.add(pr.RemoteVariable(name='RoLogicRstN',     description='Enables digital rodout clock. (Active low)',   offset=0x00000100, bitSize=1,  bitOffset=2, base=pr.Bool, mode='RW'))

--- a/shared/rtl/RegisterControlDualClock.vhd
+++ b/shared/rtl/RegisterControlDualClock.vhd
@@ -256,7 +256,7 @@ begin
    -------------------------------
    -- Configuration Register
    -------------------------------  
-   comb : process (axiReadMaster, axilRst, axiWriteMaster, r, idValids, idValues, acqStart, saciReadoutAck, asicRefClockFreq, v1LinkUp, v2LinkUp) is
+   comb : process (axiReadMaster, axilRst, axiWriteMaster, r, idValids, idValues, acqStart, digOutSync, saciReadoutAck, asicRefClockFreq, v1LinkUp, v2LinkUp, chipIdRst) is
       variable v           : RegType;
       variable regCon      : AxiLiteEndPointType;
       
@@ -416,8 +416,15 @@ begin
          v.boardRegOut.acqCnt := (others=>'0');
          v.saciPrepRdoutCnt   := (others=>'0');
       end if;
-  
-    
+      
+      for i in 0 to NUM_DS2411_G-1 loop
+        if chipIdRst(i) = '1' then
+            v.sn(i) := (others => '0');
+        elsif idValids(i) = '1' then
+            v.sn(i) := idValues(i);
+        end if;
+      end loop;
+
       -- Synchronous Reset
       if axilRst = '1' then
          v := REG_INIT_C;
@@ -448,15 +455,6 @@ begin
    begin
       if rising_edge(axilClk) then
          r <= rin after TPD_G;
-         
-         for i in 0 to NUM_DS2411_G-1 loop
-            if r.snTrigger(i) = '1' then
-                r.sn(i) <= (others => '0');
-            elsif idValids(i) = '1' then
-                r.sn(i) <= idValues(i);
-            end if;
-         end loop;
-         
       end if;
    end process seq;
 

--- a/shared/rtl/TimingRx.vhd
+++ b/shared/rtl/TimingRx.vhd
@@ -116,8 +116,9 @@ architecture mapping of TimingRx is
    signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0);
 
    signal gtRxData : slv(15 downto 0);
+   signal gtRxData_s0 : slv(15 downto 0);
    signal rxData   : slv(15 downto 0);
-
+   
    signal gtRxDataK : slv(1 downto 0);
    signal rxDataK   : slv(1 downto 0);
 
@@ -315,7 +316,7 @@ begin
             rxStatus        => gtRxStatus,
             rxUsrClkActive  => '1',
             rxUsrClk        => rxUsrClk,
-            rxData          => gtRxData,
+            rxData          => gtRxData_s0,
             rxDataK         => gtRxDataK,
             rxDispErr       => gtRxDispErr,
             rxDecErr        => gtRxDecErr,
@@ -343,6 +344,7 @@ begin
       gtTxStatus  <= TIMING_PHY_STATUS_FORCE_C;
       gtRxStatus  <= TIMING_PHY_STATUS_FORCE_C;
       gtRxData    <= (others => '0');   --temTimingTxPhy.data;
+      gtRxData_s0 <= (others => '0');
       gtRxDataK   <= (others => '0');   --temTimingTxPhy.dataK;
       gtRxDispErr <= "00";
       gtRxDecErr  <= "00";
@@ -361,6 +363,7 @@ begin
             rxDecErr  <= "00"                      after TPD_G;
          else
             rxStatus  <= gtRxStatus  after TPD_G;
+            gtRxData  <= gtRxData_s0 after TPD_G;
             rxData    <= gtRxData    after TPD_G;
             rxDataK   <= gtRxDataK   after TPD_G;
             rxDispErr <= gtRxDispErr after TPD_G;


### PR DESCRIPTION
Make the ID reading more generic:
  - Create registers according to NUM_DS2411_G value
  - 2 registers of 32 bits per line
  - Add id reset register (default to all '0')
  - Each bit of the IDreset register are connected to one DS2411Core (one line)
  - Values are stored into registers when idValids is '1'
  - Python code uses the snEnum that was existing to create the register map (dynamic)
  - Python code adds the new IDReset register

Should be compatible with previous version but it would be good to test:
  - Register map "did not" change
  - When NUM_DS2411_G is set to its default value, previous register map looks the same
  - Additional registers when NUM_DS22411_G > 2 are set in a place where there was nothing previously (explaining the limitation to 29 devices)
  - IDReset register was added in a place where there was no register
  - IDReset default value is '0', meaning that it does not reset the core
  - the default snEnum dictionary creates the same mapping as it was previously