### PR TITLE
Timing core clk bugfix at init

### DIFF
--- a/python/epix_hr_leap_common/_TimingRx.py
+++ b/python/epix_hr_leap_common/_TimingRx.py
@@ -73,6 +73,8 @@ class TimingRx(pr.Device):
             self.TimingFrameRx.C_RxReset()
             time.sleep(1.0)
             self.TimingFrameRx.RxDown.set(0) # Reset the latching register
+            self.TriggerEventManager.TriggerEventBuffer[0].TriggerSource.set(0)
+            self.TriggerEventManager.TriggerEventBuffer[1].TriggerSource.set(0)
 
         @self.command()
         def ConfigureXpmMini():

--- a/python/epix_hr_leap_common/_TimingRx.py
+++ b/python/epix_hr_leap_common/_TimingRx.py
@@ -58,13 +58,18 @@ class TimingRx(pr.Device):
         def ConfigLclsTimingV2():
             print ( 'ConfigLclsTimingV2()' )
             self.UseMiniTpg.set(0x0)
+            time.sleep(0.1)
             self.TxDbgPhyRst.set(0x1)
+            time.sleep(0.1)
             self.TxDbgPhyRst.set(0x0)
+            time.sleep(0.1)
             self.TimingFrameRx.ModeSelEn.setDisp('UseClkSel')
             self.TimingFrameRx.RxPllReset.set(1)
             time.sleep(1.0)
             self.TimingFrameRx.RxPllReset.set(0)
+            time.sleep(0.1)
             self.TimingFrameRx.ClkSel.set(0x1)
+            time.sleep(0.1)
             self.TimingFrameRx.C_RxReset()
             time.sleep(1.0)
             self.TimingFrameRx.RxDown.set(0) # Reset the latching register

--- a/python/epix_hr_leap_common/_TimingRx.py
+++ b/python/epix_hr_leap_common/_TimingRx.py
@@ -75,6 +75,7 @@ class TimingRx(pr.Device):
             self.TimingFrameRx.RxDown.set(0) # Reset the latching register
             self.TriggerEventManager.TriggerEventBuffer[0].TriggerSource.set(0)
             self.TriggerEventManager.TriggerEventBuffer[1].TriggerSource.set(0)
+            print ( 'ConfigLclsTimingV2() Done' )
 
         @self.command()
         def ConfigureXpmMini():
@@ -85,9 +86,11 @@ class TimingRx(pr.Device):
             self.XpmMiniWrapper.XpmMini.Link.set(0)
             self.XpmMiniWrapper.XpmMini.Config_L0Select_RateSel.set(5)
             self.XpmMiniWrapper.XpmMini.Config_L0Select_Enabled.set(False)
+            print ( 'ConfigureXpmMini() Done' )
 
         @self.command(description="GTX TX Reset")
         def TimingTxReset():
             print ( 'TimingTxReset()' )
             self.TxDbgPhyRst.set(0x1)
             self.TxDbgPhyRst.set(0x0)
+            print ( 'TimingTxReset() Done' )

--- a/python/epix_hr_leap_common/_TimingRx.py
+++ b/python/epix_hr_leap_common/_TimingRx.py
@@ -48,7 +48,7 @@ class TimingRx(pr.Device):
 
         self.add(l2si.TriggerEventManager(
             offset       = 0x0004_0000,
-            numDetectors = 1,
+            numDetectors = 2,
             enLclsI      = False,
             enLclsII     = True,
             expand       = True,


### PR DESCRIPTION
When initiating LCLSII timing configuation sequence, sometimes the Rx enters an unknown state, and the RxClk goes to zero. Adding delays in the configuration sequence resolves this issue. t