### PR TITLE
Increased srp fifo size and pause threshold.

### DIFF
--- a/core/rtl/PgpWrapper.vhd
+++ b/core/rtl/PgpWrapper.vhd
@@ -303,7 +303,10 @@ begin
       generic map (
          TPD_G               => TPD_G,
          GEN_SYNC_FIFO_G     => false,
-         AXI_STREAM_CONFIG_G => PGP4_AXIS_CONFIG_C)
+         AXI_STREAM_CONFIG_G => PGP4_AXIS_CONFIG_C,
+         FIFO_ADDR_WIDTH_G   => 12,
+         FIFO_PAUSE_THRESH_G => 511
+         )
       port map (
          -- Streaming Slave (Rx) Interface (sAxisClk domain)
          sAxisClk         => pgpClk(5),
@@ -345,7 +348,8 @@ begin
          TPD_G            => TPD_G,
          GEN_SYNC_FIFO_G  => true,      -- same clock domain
          PHY_AXI_CONFIG_G => PGP4_AXIS_CONFIG_C,
-         APP_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
+         APP_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C
+         )
       port map (
          -- PGP Interface (pgpClk domain)
          pgpClk      => pgpClk(5),


### PR DESCRIPTION
This modification was necessary since in the beamrtime we observed that register reads where causing overflow in pgp, and this leads us to suspect that the hardware setup latency (namely distance between node and detector) is significantly larger.